### PR TITLE
Added more game over conditions

### DIFF
--- a/ScheduleBuildingTest/Assets/Scripts/Game/StateMachine/EventState.cs
+++ b/ScheduleBuildingTest/Assets/Scripts/Game/StateMachine/EventState.cs
@@ -35,5 +35,11 @@ namespace Game.StateMachine
         { 
             stateMachine.OnEventPhaseExit.Raise();
         }
+
+        public override bool GameOverCondition()
+        {
+            if (player.Motivation <= 0) return true;
+            return GameManager.Instance.turn == 10 && player.Grade < 60;
+        }
     }
 }

--- a/ScheduleBuildingTest/Assets/Scripts/Game/StateMachine/GameState.cs
+++ b/ScheduleBuildingTest/Assets/Scripts/Game/StateMachine/GameState.cs
@@ -37,6 +37,7 @@ namespace Game.StateMachine
         public virtual void OnStateEnter()
         {
             stateEnterTime = Time.time;
+            if(GameOverCondition()) stateMachine.ChangeState(stateMachine.gameOverState);
         }
 
         /// <summary>
@@ -50,7 +51,7 @@ namespace Game.StateMachine
         // TODO: make this more robust
         public virtual bool GameOverCondition()
         {
-            return false;
+            return (player.Motivation <= 0);
         }
 
         public virtual void ApplyChoice(int selection)


### PR DESCRIPTION
state machine now enters the game over state when motivation drops below 0 or if grades are below 60 at the end of the 10th turn.